### PR TITLE
Add core_version_requirement: ^8 || ^9 for D9

### DIFF
--- a/list_predefined_options.info.yml
+++ b/list_predefined_options.info.yml
@@ -5,3 +5,4 @@ package: Fields
 dependencies:
   - options
 core: 8.x
+core_version_requirement: ^8 || ^9


### PR DESCRIPTION
Add core_version_requirement: ^8 || ^9 to designate that the module is compatible with Drupal 9. See https://drupal.org/node/3070687.